### PR TITLE
Driver rename + Record.self fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,11 @@ export const Record = {
     if (id === undefined || id === null) {
       return null
     }
+    if (self) {
+      return self;
+    }
     const { name } = parent.match(root.table())
-    return self || parent.ref.pop().push('one', { id: id })
+    return parent.ref.pop().push('one', { id: id })
   },
   fields({ source }) {
     return JSON.stringify(source.fields)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "air",
+  "name": "airtable",
   "version": "1",
   "dependencies": {
     "airtable": "^0.5.2",


### PR DESCRIPTION
Note: because of this rename `membrane update` won't work for running instances.